### PR TITLE
smaller fixes.

### DIFF
--- a/csharp/ICT/Common/Remoting/Server/DomainManager.cs
+++ b/csharp/ICT/Common/Remoting/Server/DomainManager.cs
@@ -4,7 +4,7 @@
 // @Authors:
 //       timop
 //
-// Copyright 2004-2014 by OM International
+// Copyright 2004-2016 by OM International
 //
 // This file is part of OpenPetra.org.
 //
@@ -59,7 +59,7 @@ namespace Ict.Common.Remoting.Server
         }
 
         /// <summary>
-        /// Delegate that allows <see cref="DomainManagerBase" /> to access the System Defaults Cache of OpenPetra.
+        /// Delegate that allows <see cref="DomainManager" /> to access the System Defaults Cache of OpenPetra.
         /// </summary>
         public static Func <Int64>GetSiteKeyFromSystemDefaultsCacheDelegate
         {

--- a/inc/template/src/ClientServerGlue/ClientGlue.Connector.cs
+++ b/inc/template/src/ClientServerGlue/ClientGlue.Connector.cs
@@ -51,8 +51,8 @@ try
     TheServerManager.EstablishDBConnection();
 
     TSystemDefaultsCache.GSystemDefaultsCache = new TSystemDefaultsCache();
-    DomainManager.GSiteKey = TSystemDefaultsCache.GSystemDefaultsCache.GetInt64Default(
-	Ict.Petra.Shared.SharedConstants.SYSDEFAULT_SITEKEY);
+    DomainManager.GetSiteKeyFromSystemDefaultsCacheDelegate = 
+        @TSystemDefaultsCache.GSystemDefaultsCache.GetSiteKeyDefault;
 
     TLanguageCulture.Init();
 


### PR DESCRIPTION
one for a compiler warning (cref DomainManagerBase).
the other one for compiling the standalone version, GSiteKey.