### PR TITLE
fixing problems with multi threading tests on Database connections.

### DIFF
--- a/csharp/ICT/Common/Session/Session.cs
+++ b/csharp/ICT/Common/Session/Session.cs
@@ -4,7 +4,7 @@
 // @Authors:
 //       timop, christiank
 //
-// Copyright 2004-2014 by OM International
+// Copyright 2004-2016 by OM International
 //
 // This file is part of OpenPetra.org.
 //
@@ -194,7 +194,7 @@ namespace Ict.Common.Session
         {
             SortedList <string, object>session = GetSession();
 
-            if (session.Keys.Contains(name) && (GetSession()[name] != null))
+            if (session.Keys.Contains(name) && (session[name] != null))
             {
                 return true;
             }
@@ -214,7 +214,7 @@ namespace Ict.Common.Session
 
             if (session.Keys.Contains(name))
             {
-                return GetSession()[name];
+                return session[name];
             }
 
             return null;

--- a/csharp/ICT/Testing/lib/Common/DB/test.Multithreading.cs
+++ b/csharp/ICT/Testing/lib/Common/DB/test.Multithreading.cs
@@ -2,9 +2,9 @@
 // DO NOT REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // @Authors:
-//       christiank
+//       christiank, timop
 //
-// Copyright 2004-2015 by OM International
+// Copyright 2004-2016 by OM International
 //
 // This file is part of OpenPetra.org.
 //
@@ -121,7 +121,7 @@ namespace Ict.Common.DB.Testing
                 new AsyncCallback(TestCallDBCommand1Callback), FTestCallDBCommand1);
 
             // 2nd Step: Wait until the first Thread has started the DB Transaction
-            while (DBAccess.GDBAccessObj.Transaction == null)
+            while (FTestDBInstance1 == null || FTestDBInstance1.Transaction == null)
             {
                 Thread.Sleep(100);
             }
@@ -472,11 +472,22 @@ ATransactionName: "GNoETransaction_throws_no_Exception 2"); });
                        {
                            FTestingThread1 = Thread.CurrentThread;
                            FTestingThread1.Name = String.Format(TestThreadName, AThreadNumber);
+
+                           if (FTestDBInstance1 == null)
+                           {
+                               FTestDBInstance1 = EstablishDBConnectionAndReturnIt("Thread 1", true);
+                           }
+
+                           DBAccess.GDBAccessObj = FTestDBInstance1;
                        }
                        else
                        {
                            FTestingThread2 = Thread.CurrentThread;
                            FTestingThread2.Name = String.Format(TestThreadName, AThreadNumber);
+
+                           // reusing test instance from first thread
+                           DBAccess.GDBAccessObj = FTestDBInstance1;
+                           FTestDBInstance2 = DBAccess.GDBAccessObj;
                        }
 
                        try
@@ -649,6 +660,8 @@ ATransactionName: "GNoETransaction_throws_proper_Exception " + AThreadNumber.ToS
 
             // Create a separate instance of TDataBase and establish a separate DB connection on it
             TestDBInstance = EstablishDBConnectionAndReturnIt(String.Format(TestConnectionName, 1), false);
+            DBAccess.GDBAccessObj = TestDBInstance;
+            FTestDBInstance1 = TestDBInstance;
 
             //
             // Act
@@ -671,7 +684,7 @@ ATransactionName: "GNoETransaction_throws_proper_Exception " + AThreadNumber.ToS
             DBTransOnDefaultTDataBaseInstance = DBAccess.GDBAccessObj.Transaction;
 
             // Guard Assert
-            Assert.IsNotNull(DBTransOnDefaultTDataBaseInstance);
+            Assert.IsNotNull(DBTransOnDefaultTDataBaseInstance, "DBTransOnDefaultTDataBaseInstance must not be null");
 
             // Primary Assert
             Assert.IsFalse(TDataBase.CheckDBTransactionThreadIsCompatible(DBTransOnDefaultTDataBaseInstance),
@@ -770,6 +783,10 @@ ATransactionName: "GNoETransaction_throws_proper_Exception " + AThreadNumber.ToS
             // another Thread, which otherwise is not possible within a NUnit Test!
             FTestCallDBCommand1 = GetActionDelegateForGNoET(1, false);
 
+            // Create an instance of TDataBase and establish a DB connection on it
+            TDataBase TestDBInstance = EstablishDBConnectionAndReturnIt(String.Format(TestConnectionName, 1), false);
+            DBAccess.GDBAccessObj = TestDBInstance;
+            FTestDBInstance1 = TestDBInstance;
 
             //
             // Act
@@ -792,7 +809,7 @@ ATransactionName: "GNoETransaction_throws_proper_Exception " + AThreadNumber.ToS
             DBTransOnDefaultTDataBaseInstance = DBAccess.GDBAccessObj.Transaction;
 
             // Guard Assert
-            Assert.IsNotNull(DBTransOnDefaultTDataBaseInstance);
+            Assert.IsNotNull(DBTransOnDefaultTDataBaseInstance, "DBTransOnDefaultTDataBaseInstance must not be null");
 
             // Primary Assert
             Assert.IsFalse(DBAccess.GDBAccessObj.CheckRunningDBTransactionThreadIsCompatible(),
@@ -945,6 +962,11 @@ ATransactionName: "GNoETransaction_throws_proper_Exception " + AThreadNumber.ToS
             // another Thread, which otherwise is not possible within a NUnit Test!
             FTestCallDBCommand1 = GetActionDelegateForGNoET(1, false);
 
+            // Create an instance of TDataBase and establish a DB connection on it
+            TDataBase TestDBInstance = EstablishDBConnectionAndReturnIt(String.Format(TestConnectionName, 1), false);
+            DBAccess.GDBAccessObj = TestDBInstance;
+            FTestDBInstance1 = TestDBInstance;
+
 
             //
             // Act
@@ -967,7 +989,7 @@ ATransactionName: "GNoETransaction_throws_proper_Exception " + AThreadNumber.ToS
             DBTransOnDefaultTDataBaseInstance = DBAccess.GDBAccessObj.Transaction;
 
             // Guard Assert
-            Assert.IsNotNull(DBTransOnDefaultTDataBaseInstance);
+            Assert.IsNotNull(DBTransOnDefaultTDataBaseInstance, "DBTransOnDefaultTDataBaseInstance must not be null");
 
             // Primary Assert
             Assert.IsFalse(DBAccess.GDBAccessObj.CheckRunningDBTransactionIsCompatible(IsolationLevel.ReadCommitted,


### PR DESCRIPTION
with the web services, we have strict separation of database objects between threads, therefore need to have workarounds to make the tests still work