### PR TITLE
fix problem with Mono 4.6 related to Jayrock.Json

### DIFF
--- a/csharp/ICT/Testing/lib/Common/IO/test.cs
+++ b/csharp/ICT/Testing/lib/Common/IO/test.cs
@@ -4,7 +4,7 @@
 // @Authors:
 //       timop
 //
-// Copyright 2004-2014 by OM International
+// Copyright 2004-2017 by OM International
 //
 // This file is part of OpenPetra.org.
 //
@@ -27,6 +27,7 @@ using NUnit.Framework;
 using System.Threading;
 using System.Collections;
 using System.Collections.Specialized;
+using System.Dynamic;
 using System.Globalization;
 using System.Xml;
 using System.Text;

--- a/csharp/ThirdParty/namespace.map
+++ b/csharp/ThirdParty/namespace.map
@@ -26,6 +26,7 @@ System.Data*=${csharpStdLibs}/System.Data.dll
 System.Design*=${csharpStdLibs}/System.Design.dll
 System.Drawing.Design*=${csharpStdLibs}/System.Drawing.Design.dll
 System.Drawing*=${csharpStdLibs}/System.Drawing.dll
+System.Dynamic=${csharpStdLibs}/System.Core.dll
 System.Linq*=${csharpStdLibs}/System.Core.dll
 System.Security*=${csharpStdLibs}/System.Security.dll
 System.Runtime.Remoting=${csharpStdLibs}/System.Runtime.Remoting.dll


### PR DESCRIPTION
the error message was:
[00:15:48] /root/lbs-openpetra/openpetra-test-server-sqlite/openpetra-test/csharp/ICT/Testing/lib/Common/IO/test.cs(423,13) : error CS0012: The type `System.Dynamic.IDynamicMetaObjectProvider' is defined in an assembly that is not referenced. Consider adding a reference to assembly `System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'